### PR TITLE
Better xdg base dir support

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -40,9 +40,10 @@ def check_live():
     f = open("/proc/cmdline", "r").read()
     return "boot=live" in f
 
+config_dir = os.getenv("XDG_CONFIG_HOME", str(Path.home()) + "/.config/")
 
 autostart_file = (
-    str(Path.home()) + "/.config/autostart/tr.org.pardus.pardus-gnome-greeter.desktop"
+    config_dir + "/autostart/tr.org.pardus.pardus-gnome-greeter.desktop"
 )
 
 # In live mode, the application should not welcome the user

--- a/src/Pages/Theme.py
+++ b/src/Pages/Theme.py
@@ -156,11 +156,11 @@ def fun_change_theme(toggle_button, theme, is_special=False):
 
 def fun_check_special_themes():
     themes = ["pardus-yuzyil"]
-    home_path = Path.home()
+    config_dir = os.getenv("XDG_CONFIG_HOME", str(Path.home()) + "/.config/")
     lang = os.getenv("LANG")[0:2]
     desktop_env = utils.desktop_env()
     user_theme_json = (
-        f"{home_path}/.config/pardus/pardus-special-theme/special-theme.json"
+        f"{config_dir}/pardus/pardus-special-theme/special-theme.json"
     )
     user_theme_json_ok = os.path.isfile(user_theme_json)
 


### PR DESCRIPTION
## Description

This PR removes the hardcoded path for the user configuration directory ($HOME/.config/) and instead uses the environment variable XDG_CONFIG_HOME. This allows users to have more control over where the configuration files are stored.

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My commits follow the commit standards of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings