### PR TITLE
fix: When nautilus is not installed, disable the options that requires it

### DIFF
--- a/data/po/es.po
+++ b/data/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 16:36+0300\n"
+"POT-Creation-Date: 2025-07-09 16:19+0300\n"
 "PO-Revision-Date: 2022-10-18 11:11+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,12 +17,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.4.2\n"
 
-
 # MainWindow.py
 msgid "Pardus GNOME Greeter"
 msgstr "Bienvenido/a a Pardus GNOME"
-
-
 
 msgid "Welcome"
 msgstr "Bienvenido/a"
@@ -66,16 +63,12 @@ msgstr "Cerrar"
 msgid "Contributors"
 msgstr "Contribuidores"
 
-
-
 # Apps.py
 msgid "Pardus Software Center"
 msgstr "Centro de Software Pardus"
 
 msgid "For more applications"
 msgstr "Para mas aplicaciones"
-
-
 
 # Theme.py
 msgid "Dark Theme"
@@ -84,15 +77,12 @@ msgstr "Tema Oscuro"
 msgid "Light Theme"
 msgstr "Tema Claro"
 
-
 # Layout.py
 msgid "Style"
 msgstr "Estilo"
 
 msgid "Classic"
 msgstr "Clásico"
-
-
 
 # Display.py
 msgid "Recommended scale option for main display is"
@@ -122,6 +112,9 @@ msgstr "Tamaño de iconos del gestor de ficheros"
 msgid "Desktop icon size"
 msgstr "Tamaño de iconos del escritorio"
 
+msgid ""
+"Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
 
 # Outro.py
 msgid "Social Media Accounts"
@@ -145,7 +138,6 @@ msgstr "Comunidad"
 msgid "Forum"
 msgstr "Foro"
 
-
 # Clock
 msgid "Enable clock formatting"
 msgstr "Activar formato de reloj"
@@ -159,11 +151,9 @@ msgstr "Tamaño fuente"
 msgid "Show Seconds"
 msgstr "Mostrar segundos"
 
-
 # Welcome.py
 msgid "This application helps configure Pardus"
 msgstr "Esta aplicación ayuda a configurar Pardus"
-
 
 # Extension
 msgid "Add a quick navigation menu for system places."
@@ -178,14 +168,26 @@ msgstr "Deshabilitar salvapantallas y auto-suspensión."
 msgid "Add a category-based application menu."
 msgstr "Añade un menu categorizado de aplicaciones."
 
-msgid "Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons in the Shell."
-msgstr "Activar soporte para AppIndicator, KSstatusNotifierItem y iconos de legado en la bandeja del sistema en el intérprete de comandos."
+msgid ""
+"Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons "
+"in the Shell."
+msgstr ""
+"Activar soporte para AppIndicator, KSstatusNotifierItem y iconos de legado "
+"en la bandeja del sistema en el intérprete de comandos."
 
-msgid "Eliminates the 'Windows is ready' notification and brings the window into focus."
-msgstr "Elimina la notificación de 'Ventana lista' y hace que la ventana se enfoque."
+msgid ""
+"Eliminates the 'Windows is ready' notification and brings the window into "
+"focus."
+msgstr ""
+"Elimina la notificación de 'Ventana lista' y hace que la ventana se enfoque."
 
 msgid "Cutting-edge clipboard manager for GNOME Shell."
 msgstr "Gestor de portapapeles moderno para ambiente GNOME."
 
 msgid "Adds clipboard indicator to top panel, caches history."
-msgstr "Añade el indicador de portapapeles al panel superior y guarda el historial en caché."
+msgstr ""
+"Añade el indicador de portapapeles al panel superior y guarda el historial "
+"en caché."
+
+msgid "Provides quick access to Bluetooth"
+msgstr ""

--- a/data/po/pardus-gnome-greeter.pot
+++ b/data/po/pardus-gnome-greeter.pot
@@ -1,28 +1,25 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the pardus-gnome-greeter package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: \n"
+"Project-Id-Version: pardus-gnome-greeter\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 16:36+0300\n"
-"PO-Revision-Date: 2022-10-18 11:11+0300\n"
-"Last-Translator: \n"
-"Language-Team: \n"
-"Language: tr\n"
+"POT-Creation-Date: 2025-07-09 16:19+0300\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.2\n"
-
 
 # MainWindow.py
 msgid "Pardus GNOME Greeter"
 msgstr ""
-
-
 
 msgid "Welcome"
 msgstr ""
@@ -66,16 +63,12 @@ msgstr ""
 msgid "Contributors"
 msgstr ""
 
-
-
 # Apps.py
 msgid "Pardus Software Center"
 msgstr ""
 
 msgid "For more applications"
 msgstr ""
-
-
 
 # Theme.py
 msgid "Dark Theme"
@@ -84,15 +77,12 @@ msgstr ""
 msgid "Light Theme"
 msgstr ""
 
-
 # Layout.py
 msgid "Style"
 msgstr ""
 
 msgid "Classic"
 msgstr ""
-
-
 
 # Display.py
 msgid "Recommended scale option for main display is"
@@ -122,6 +112,9 @@ msgstr ""
 msgid "Desktop icon size"
 msgstr ""
 
+msgid ""
+"Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
 
 # Outro.py
 msgid "Social Media Accounts"
@@ -145,7 +138,6 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-
 # Clock
 msgid "Enable clock formatting"
 msgstr ""
@@ -159,11 +151,9 @@ msgstr ""
 msgid "Show Seconds"
 msgstr ""
 
-
 # Welcome.py
 msgid "This application helps configure Pardus"
 msgstr ""
-
 
 # Extension
 msgid "Add a quick navigation menu for system places."
@@ -178,10 +168,14 @@ msgstr ""
 msgid "Add a category-based application menu."
 msgstr ""
 
-msgid "Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons in the Shell."
+msgid ""
+"Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons "
+"in the Shell."
 msgstr ""
 
-msgid "Eliminates the 'Windows is ready' notification and brings the window into focus."
+msgid ""
+"Eliminates the 'Windows is ready' notification and brings the window into "
+"focus."
 msgstr ""
 
 msgid "Cutting-edge clipboard manager for GNOME Shell."

--- a/data/po/pt.po
+++ b/data/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pardus-gnome-greeter\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 16:36+0300\n"
+"POT-Creation-Date: 2025-07-09 16:19+0300\n"
 "PO-Revision-Date: 2025-04-10 21:28+0100\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
@@ -112,6 +112,10 @@ msgstr "Tamanho dos ícones do gestor de ficheiros"
 
 msgid "Desktop icon size"
 msgstr "Tamanho dos ícones da área de trabalho"
+
+msgid ""
+"Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
 
 # Outro.py
 msgid "Social Media Accounts"

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -7,15 +7,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-08-04 16:36+0300\n"
-"PO-Revision-Date: 2022-10-18 11:11+0300\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2025-07-09 16:19+0300\n"
+"PO-Revision-Date: 2025-07-09 16:20+0300\n"
+"Last-Translator: Edip Hazuri <edip@medip.dev>\n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 3.6\n"
 
 # MainWindow.py
 msgid "Pardus GNOME Greeter"
@@ -41,9 +41,6 @@ msgstr "Uzantılar"
 
 msgid "Display"
 msgstr "Ekran"
-
-msgid "Clock"
-msgstr "Saat"
 
 msgid "Applications"
 msgstr "Uygulamalar"
@@ -73,7 +70,6 @@ msgstr "Pardus Yazılım Merkezi"
 msgid "For more applications"
 msgstr "Daha fazla uygulama için"
 
-
 # Theme.py
 msgid "Dark Theme"
 msgstr "Koyu Tema"
@@ -87,23 +83,6 @@ msgstr "Tarzı"
 
 msgid "Classic"
 msgstr "Klasik"
-
-
-# Clock
-msgid "Enable clock formatting"
-msgstr "Saat özelleştirmeyi etkinleştir"
-
-msgid "Date / Time Format"
-msgstr "Tarih / Saat Düzeni"
-
-msgid "Font Size"
-msgstr "Yazı Tipi Boyutu"
-
-msgid "Show Seconds"
-msgstr "Saniyeleri Göster"
-
-
-
 
 # Display.py
 msgid "Recommended scale option for main display is"
@@ -133,7 +112,11 @@ msgstr "Dosya yöneticisi simge boyutu"
 msgid "Desktop icon size"
 msgstr "Masaüstü simge boyutu"
 
-
+msgid ""
+"Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
+"Nautilus dosya yöneticisi kurulu olmadığı için bazı seçenekler devre dışı "
+"bırakılmıştır."
 
 # Outro.py
 msgid "Social Media Accounts"
@@ -157,6 +140,19 @@ msgstr "Topluluk"
 msgid "Forum"
 msgstr "Forum"
 
+# Clock
+msgid "Enable clock formatting"
+msgstr "Saat özelleştirmeyi etkinleştir"
+
+msgid "Date / Time Format"
+msgstr "Tarih / Saat Düzeni"
+
+msgid "Font Size"
+msgstr "Yazı Tipi Boyutu"
+
+msgid "Show Seconds"
+msgstr "Saniyeleri Göster"
+
 # Welcome.py
 msgid "This application helps configure Pardus"
 msgstr "Bu uygulama Pardusʼu özelleştirmenize yardımcı olur"
@@ -174,10 +170,16 @@ msgstr "Ekran koruyucu ve otomatik uyku kipini devre dışı bırak."
 msgid "Add a category-based application menu."
 msgstr "Kategori tabanlı uygulama menüsü ekle."
 
-msgid "Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons in the Shell."
-msgstr "AppIndicator, KStatusNotifierItem ve eski Tepsi simgelerini Shell'de desteklemeyi etkinleştirir."
+msgid ""
+"Enables support for AppIndicator, KStatusNotifierItem, and legacy Tray icons "
+"in the Shell."
+msgstr ""
+"AppIndicator, KStatusNotifierItem ve eski Tepsi simgelerini Shell'de "
+"desteklemeyi etkinleştirir."
 
-msgid "Eliminates the 'Windows is ready' notification and brings the window into focus."
+msgid ""
+"Eliminates the 'Windows is ready' notification and brings the window into "
+"focus."
 msgstr "'Pencere hazır' bildirimini kaldırır ve pencereyi odaklar."
 
 msgid "Cutting-edge clipboard manager for GNOME Shell."
@@ -188,3 +190,6 @@ msgstr "Üst panele pano göstergesi ekler, geçmişi önbelleğe alır."
 
 msgid "Provides quick access to Bluetooth"
 msgstr "Bluetooth'a hızlı erişim sağlar"
+
+#~ msgid "Clock"
+#~ msgstr "Saat"

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: ${misc:Depends},
   gnome-shell-extension-date-menu-formatter,
   gnome-shell-extension-no-annoyance,
   gnome-shell-extension-bluetooth-battery-meter
+Recommends: nautilus
 Breaks: pardus-welcome
 Description: Personalize your Pardus desktop with Pardus GNOME Greeter.
  This application offers easy customization of wallpapers,

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,7 @@ sys.path.append("../")
 
 
 gi.require_version("Gdk", "4.0")
-from gi.repository import Gdk
+from gi.repository import Gdk, Gio
 from libpardus import Ptk
 
 
@@ -85,3 +85,11 @@ def dconf_reset(path):
 
 def desktop_env():
     return os.environ["XDG_CURRENT_DESKTOP"].lower()
+
+def is_gsettings_schema_exists(schema):
+    schema_source = Gio.SettingsSchemaSource.get_default()
+    schema_obj = schema_source.lookup(schema, False)
+    if schema_obj is None:
+        return False
+
+    return True


### PR DESCRIPTION
## Description

Although it's forgotten to add to package dependencies. Nautilus currently is a hard-dependency of this app. If you try to launch the app while Nautilus is not installed (spesifically nautilus-data package is not installed) it will not start and throw "Glib-GIO-ERROR **: Settings schema 'org.gnome.nautilus.icon-view' is not installed" error. 
Since some users may not want to use/install Nautilus i made sure that the app will launch without Nautilus installed, makes it an optional dependency and shows a warn message for the user in the UI.

I am not sure if the [gscheme lookup function](https://github.com/Vilez0/pardus-gnome-greeter/blob/28a8ab821dc73a919ab85b8c6ac8b5783a188feb/src/utils.py#L89) should be here, or if I should open a PR to libpardus. I welcome your feedback.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My commits follow the commit standards of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings