### PR TITLE
fix: When nautilus is not installed, disable the options that requires it

### DIFF
--- a/data/po/es.po
+++ b/data/po/es.po
@@ -122,6 +122,8 @@ msgstr "Tamaño de iconos del gestor de ficheros"
 msgid "Desktop icon size"
 msgstr "Tamaño de iconos del escritorio"
 
+msgid "Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
 
 # Outro.py
 msgid "Social Media Accounts"

--- a/data/po/pardus-gnome-greeter.pot
+++ b/data/po/pardus-gnome-greeter.pot
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the pardus-gnome-greeter package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
@@ -120,6 +120,9 @@ msgid "File manager icon size"
 msgstr ""
 
 msgid "Desktop icon size"
+msgstr ""
+
+msgid "Some options were disabled because Nautilus file manager is not installed"
 msgstr ""
 
 

--- a/data/po/pt.po
+++ b/data/po/pt.po
@@ -113,6 +113,9 @@ msgstr "Tamanho dos ícones do gestor de ficheiros"
 msgid "Desktop icon size"
 msgstr "Tamanho dos ícones da área de trabalho"
 
+msgid "Some options were disabled because Nautilus file manager is not installed"
+msgstr ""
+
 # Outro.py
 msgid "Social Media Accounts"
 msgstr "Contas de redes sociais"

--- a/data/po/tr.po
+++ b/data/po/tr.po
@@ -133,6 +133,9 @@ msgstr "Dosya yöneticisi simge boyutu"
 msgid "Desktop icon size"
 msgstr "Masaüstü simge boyutu"
 
+msgid "Some options were disabled because Nautilus file manager is not installed"
+msgstr "Nautilus dosya yöneticisi kurulu olmadığı için bazı seçenekler devre dışı bırakıldı"
+
 
 
 # Outro.py

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: ${misc:Depends},
   gnome-shell-extension-date-menu-formatter,
   gnome-shell-extension-no-annoyance,
   gnome-shell-extension-bluetooth-battery-meter
+Recommends: nautilus
 Breaks: pardus-welcome
 Description: Personalize your Pardus desktop with Pardus GNOME Greeter.
  This application offers easy customization of wallpapers,

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,7 +7,7 @@ sys.path.append("../")
 
 
 gi.require_version("Gdk", "4.0")
-from gi.repository import Gdk
+from gi.repository import Gdk, Gio
 from libpardus import Ptk
 
 
@@ -85,3 +85,11 @@ def dconf_reset(path):
 
 def desktop_env():
     return os.environ["XDG_CURRENT_DESKTOP"].lower()
+
+def is_gsettings_schema_exists(schema):
+    schema_source = Gio.SettingsSchemaSource.get_default()
+    schema_obj = schema_source.lookup(schema, False)
+    if schema_obj is None:
+        return False
+
+    return True


### PR DESCRIPTION
## Description

Although it's forgotten to add to package dependencies. Nautilus currently is a hard-dependency of this app. If you try to launch the app while Nautilus is not installed (spesifically nautilus-data package is not installed) it will not start and throw `"Glib-GIO-ERROR **: Settings schema 'org.gnome.nautilus.icon-view' is not installed"`. 
Since some users may not want to use/install Nautilus i made sure that the app will launch without Nautilus installed, makes it an optional dependency and shows a warn message for the user in the UI.

**Note:** _I am not sure if the [gscheme lookup function](https://github.com/Vilez0/pardus-gnome-greeter/blob/28a8ab821dc73a919ab85b8c6ac8b5783a188feb/src/utils.py#L89) should be here, or if I should open a PR to libpardus. I welcome your feedback._

Screenshot (Nautilus isn't installed):
<img width="845" height="664" alt="image" src="https://github.com/user-attachments/assets/3fe01237-924c-4ec7-bd0d-8dc2d94d72fd" />

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My commits follow the commit standards of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings