### PR TITLE
Fix minimum window size and meson build.

### DIFF
--- a/pardus-gnome-greeter.gresource.xml
+++ b/pardus-gnome-greeter.gresource.xml
@@ -85,11 +85,15 @@
     <file>assets/themes/theme-light.png</file>
     
     <!-- Screenshot Assets -->
-    <file>assets/screenshots/screenshot-1.png</file>
-    <file>assets/screenshots/screenshot-2.png</file>
-    <file>assets/screenshots/screenshot-3.png</file>
-    <file>assets/screenshots/screenshot-4.png</file>
-    
+    <file>assets/screenshots/ss1.png</file>
+    <file>assets/screenshots/ss2.png</file>
+    <file>assets/screenshots/ss3.png</file>
+    <file>assets/screenshots/ss4.png</file>
+    <file>assets/screenshots/ss5.png</file>
+    <file>assets/screenshots/ss6.png</file>
+    <file>assets/screenshots/ss7.png</file>
+    <file>assets/screenshots/ss8.png</file>
+
     <!-- Icon Assets -->
     <file>icons/github-symbolic.svg</file>
     <file>icons/linkedin-symbolic.svg</file>

--- a/src/pardus_gnome_greeter/main_window.py
+++ b/src/pardus_gnome_greeter/main_window.py
@@ -28,8 +28,8 @@ class MainWindow(Adw.ApplicationWindow):
         super().__init__(**kwargs)
         
         # Set minimum window size (but still resizable)
-        #self.set_size_request(970, 750)
-        
+        self.set_size_request(765, 750)
+
         # Load custom CSS
         css_provider = Gtk.CssProvider()
         css_provider.load_from_resource('/tr/org/pardus/pardus-gnome-greeter/css/style.css')


### PR DESCRIPTION
## Description

MainWindow didn't have a minimum size, because of that I could hide some UI elements when I make the window size too small.

I couldn't build the project with meson because of some wrong paths of screenshots were forgotten in gresource 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My commits follow the commit standards of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

Before:

https://github.com/user-attachments/assets/ac06f616-810c-47ce-b024-578f006908fb

After:

https://github.com/user-attachments/assets/0a69db04-af9b-47c4-a659-2272f267167d

